### PR TITLE
Write injections for each IFO in InferenceFile

### DIFF
--- a/bin/inference/pycbc_inference
+++ b/bin/inference/pycbc_inference
@@ -41,7 +41,6 @@ from pycbc.inference import option_utils
 from pycbc.inference import prior
 from pycbc.inference import burn_in
 from pycbc import gate
-#import h5py
 
 # command line usage
 parser = argparse.ArgumentParser(usage=__file__ + " [--options]",

--- a/bin/inference/pycbc_inference
+++ b/bin/inference/pycbc_inference
@@ -41,7 +41,7 @@ from pycbc.inference import option_utils
 from pycbc.inference import prior
 from pycbc.inference import burn_in
 from pycbc import gate
-import h5py
+#import h5py
 
 # command line usage
 parser = argparse.ArgumentParser(usage=__file__ + " [--options]",
@@ -186,28 +186,6 @@ if 'data' in likelihood_class.required_kwargs:
 else:
     strain_dict = stilde_dict = psd_dict = low_frequency_cutoff_dict = None
 
-# Get injection parameters if reading an injection file
-if opts.injection_file:
-    # Check if it's an hdf file
-    filename = opts.injection_file.values()[0]
-    if filename.endswith('.hdf') or filename.endswith('.h5'):
-        injfile = h5py.File(filename, 'r')
-        injparams = injfile.keys()
-        injvalues = {param: injfile[param][:] for param in injparams}
-        num_of_injs = len(injvalues.values()[0])
-        # Check if there are any static args in file
-        try :
-            static_args = injfile.attrs['static_args']
-        except KeyError:
-            static_args = []
-        injparams.extend(static_args)
-        # Read any static args in injection file
-        # The static args would be the same for all the injections
-        for x in static_args:
-            injvalues[x] = numpy.repeat(injfile.attrs[x], num_of_injs)
-    else :
-        injvalues = None
-
 with ctx:
 
     # read configuration file
@@ -291,17 +269,30 @@ with ctx:
     # create sampler that will run
     sampler = option_utils.sampler_from_cli(opts, likelihood)
 
-    # save command line and data, if desired
+    # save information about this data and settings
     with InferenceFile(opts.output_file, "w") as fp:
+
+        # save command line and data
         logging.info("Writing command line and data to output file")
         fp.write_command_line()
         fp.write_data(strain_dict=strain_dict if opts.save_strain else None,
                       stilde_dict=stilde_dict if opts.save_stilde else None,
                       psd_dict=psd_dict if opts.save_psd else None,
                       low_frequency_cutoff_dict=low_frequency_cutoff_dict)
-        if injvalues is not None :
-            logging.info("Writing injection parameters to output file")
-            fp.write_inj_params(injvalues)
+
+        # save injection parameters
+        if opts.injection_file:
+            for ifo in opts.instruments:
+                logging.info("Writing %s injections to output file", ifo)
+                if ifo in opts.injection_file.keys():
+                    inj_file = opts.injection_file[ifo]
+                elif len(opts.injection_file) == 1:
+                    inj_file = opts.injection_file.values()[0]
+                else:
+                    logging.warn("Could not find injections for %s", ifo)
+                    continue
+                fp.write_injections(opts.injection_file.values()[0], ifo)
+
 
     # set the walkers initial positions from a pre-existing InferenceFile
     # or a specific initial distribution listed in the configuration file

--- a/pycbc/io/inference_hdf.py
+++ b/pycbc/io/inference_hdf.py
@@ -496,20 +496,26 @@ class InferenceFile(h5py.File):
         if strain_dict is not None:
             self.write_strain(strain_dict, group=group)
 
-    def write_inj_params(self, injvalues):
-        """Write injection parameters to file.
+    def write_injections(self, injection_file, ifo):
+        """ Writes injection parameters for an IFO to file.
 
         Parameters
         ----------
-        injvalues : A dictionary of injection parameters.
+        injection_file : str
+            Path to HDF injection file.
+        ifo : str
+            IFO name.
         """
-        group = "injection_parameters"
-        self.create_group(group)
-        for param in injvalues :
-            try:
-                self[group][param][:] = injvalues[param]
-            except:
-                self[group][param] = injvalues[param]
+        subgroup = "{ifo}/injections"
+        self.create_group(subgroup.format(ifo=ifo))
+        try:
+            with h5py.File(injection_file, "r") as fp:
+                for param in fp.keys():
+                    self[subgroup.format(ifo=ifo)][param] = fp[param][:]
+                for key in fp.attrs.keys():
+                    self[subgroup.format(ifo=ifo)].attrs[key] = fp.attrs[key]
+        except IOError:
+            logging.warn("Could not read %s as an HDF file", injection_file)
 
     def write_command_line(self):
         """Writes command line to attributes.


### PR DESCRIPTION
This updates your ``write_inj_params`` branch:
  * Removes handling HDF-level functions in ``pycbc_inference`` and moves those to ``InferenceFile.write_injections``.
 * The command line option ``--injection-files`` can have argument ``[IFO:]injection_file`` for each IFO. If someone decided to use that feature, this branch as is wouldn't support this. This PR allows the injections for each IFO to be written to file. Not quite sure why this option would be used this way but if we allow it, then we might as well support it.